### PR TITLE
Add Three.js 3D “乡下老鼠进城” survival game

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,0 +1,279 @@
+const state = {
+  lives: 3,
+  distance: 0,
+  speed: 0.18,
+  sprintMultiplier: 1.8,
+  jumpVelocity: 0,
+  isJumping: false,
+  isPaused: false,
+  isGameOver: false,
+};
+
+const scene = new THREE.Scene();
+scene.fog = new THREE.Fog(0x0d0f1a, 10, 60);
+
+const camera = new THREE.PerspectiveCamera(
+  60,
+  window.innerWidth / window.innerHeight,
+  0.1,
+  200
+);
+
+const renderer = new THREE.WebGLRenderer({ antialias: true });
+renderer.setSize(window.innerWidth, window.innerHeight);
+renderer.setPixelRatio(window.devicePixelRatio || 1);
+document.body.appendChild(renderer.domElement);
+
+const loader = document.getElementById("loader");
+loader?.classList.add("hidden");
+
+const ambient = new THREE.AmbientLight(0xaab8ff, 0.6);
+scene.add(ambient);
+
+const directional = new THREE.DirectionalLight(0xffffff, 0.8);
+directional.position.set(6, 10, 4);
+scene.add(directional);
+
+const ground = new THREE.Mesh(
+  new THREE.PlaneGeometry(120, 120, 1, 1),
+  new THREE.MeshStandardMaterial({ color: 0x1b223d })
+);
+ground.rotation.x = -Math.PI / 2;
+scene.add(ground);
+
+const grid = new THREE.GridHelper(120, 24, 0x2a355f, 0x1d2644);
+scene.add(grid);
+
+const mouseGroup = new THREE.Group();
+const mouseBody = new THREE.Mesh(
+  new THREE.SphereGeometry(0.5, 24, 24),
+  new THREE.MeshStandardMaterial({ color: 0xf5d7b2 })
+);
+const mouseNose = new THREE.Mesh(
+  new THREE.ConeGeometry(0.18, 0.4, 16),
+  new THREE.MeshStandardMaterial({ color: 0xff9bb0 })
+);
+mouseNose.position.set(0, 0, 0.6);
+mouseNose.rotation.x = Math.PI / 2;
+const mouseTail = new THREE.Mesh(
+  new THREE.CylinderGeometry(0.05, 0.05, 0.8, 8),
+  new THREE.MeshStandardMaterial({ color: 0xf0c4a0 })
+);
+mouseTail.position.set(0, 0.1, -0.8);
+mouseTail.rotation.x = Math.PI / 2;
+mouseGroup.add(mouseBody, mouseNose, mouseTail);
+mouseGroup.position.set(0, 0.6, 6);
+scene.add(mouseGroup);
+
+const cityBlocks = [];
+for (let i = 0; i < 12; i += 1) {
+  const block = new THREE.Mesh(
+    new THREE.BoxGeometry(3, 3 + Math.random() * 4, 3),
+    new THREE.MeshStandardMaterial({
+      color: new THREE.Color(`hsl(${220 + Math.random() * 40}, 40%, ${30 + i}%)`),
+    })
+  );
+  block.position.set(
+    (i % 2 === 0 ? -1 : 1) * (6 + Math.random() * 2),
+    block.geometry.parameters.height / 2 - 0.1,
+    -i * 6
+  );
+  cityBlocks.push(block);
+  scene.add(block);
+}
+
+const obstacleData = [
+  { label: "猫", color: 0xff7b89, size: 0.8 },
+  { label: "狗", color: 0xffc857, size: 0.9 },
+  { label: "汽车", color: 0x5cf1ff, size: 1.1 },
+  { label: "人", color: 0x9b7bff, size: 0.95 },
+];
+
+const obstacles = [];
+
+const createLabelSprite = (text) => {
+  const canvas = document.createElement("canvas");
+  const ctx = canvas.getContext("2d");
+  canvas.width = 256;
+  canvas.height = 128;
+  ctx.fillStyle = "rgba(8,12,28,0.8)";
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.font = "bold 42px sans-serif";
+  ctx.fillStyle = "#e6ecff";
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.fillText(text, canvas.width / 2, canvas.height / 2);
+  const texture = new THREE.CanvasTexture(canvas);
+  const material = new THREE.SpriteMaterial({ map: texture });
+  const sprite = new THREE.Sprite(material);
+  sprite.scale.set(1.6, 0.8, 1);
+  return sprite;
+};
+
+const spawnObstacle = () => {
+  const type = obstacleData[Math.floor(Math.random() * obstacleData.length)];
+  const mesh = new THREE.Mesh(
+    new THREE.BoxGeometry(type.size, type.size, type.size),
+    new THREE.MeshStandardMaterial({ color: type.color })
+  );
+  mesh.userData = { type };
+  mesh.position.set(
+    (Math.random() - 0.5) * 8,
+    type.size / 2,
+    -30 - Math.random() * 30
+  );
+  const label = createLabelSprite(type.label);
+  label.position.set(0, type.size + 0.6, 0);
+  mesh.add(label);
+  obstacles.push(mesh);
+  scene.add(mesh);
+};
+
+for (let i = 0; i < 8; i += 1) {
+  spawnObstacle();
+}
+
+const keys = new Set();
+window.addEventListener("keydown", (event) => {
+  if (event.key.toLowerCase() === "p") {
+    state.isPaused = !state.isPaused;
+    return;
+  }
+  keys.add(event.key.toLowerCase());
+});
+window.addEventListener("keyup", (event) => {
+  keys.delete(event.key.toLowerCase());
+});
+
+const livesEl = document.getElementById("lives");
+const distanceEl = document.getElementById("distance");
+const overlay = document.getElementById("overlay");
+const message = document.getElementById("message");
+const restartBtn = document.getElementById("restart");
+const playAgainBtn = document.getElementById("play-again");
+
+const resetGame = () => {
+  state.lives = 3;
+  state.distance = 0;
+  state.speed = 0.18;
+  state.jumpVelocity = 0;
+  state.isJumping = false;
+  state.isPaused = false;
+  state.isGameOver = false;
+  mouseGroup.position.set(0, 0.6, 6);
+  obstacles.forEach((mesh) => scene.remove(mesh));
+  obstacles.length = 0;
+  for (let i = 0; i < 8; i += 1) {
+    spawnObstacle();
+  }
+  overlay?.classList.add("hidden");
+  updateHud();
+};
+
+restartBtn?.addEventListener("click", resetGame);
+playAgainBtn?.addEventListener("click", resetGame);
+
+const updateHud = () => {
+  if (livesEl) livesEl.textContent = String(state.lives);
+  if (distanceEl) distanceEl.textContent = Math.floor(state.distance).toString();
+};
+
+const onResize = () => {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+};
+window.addEventListener("resize", onResize);
+
+const applyControls = () => {
+  const moveSpeed = (keys.has("shift") ? state.sprintMultiplier : 1) * 0.18;
+  if (keys.has("a") || keys.has("arrowleft")) {
+    mouseGroup.position.x -= moveSpeed;
+  }
+  if (keys.has("d") || keys.has("arrowright")) {
+    mouseGroup.position.x += moveSpeed;
+  }
+  if (keys.has("w") || keys.has("arrowup")) {
+    mouseGroup.position.z -= moveSpeed;
+  }
+  if (keys.has("s") || keys.has("arrowdown")) {
+    mouseGroup.position.z += moveSpeed;
+  }
+
+  mouseGroup.position.x = THREE.MathUtils.clamp(mouseGroup.position.x, -5, 5);
+  mouseGroup.position.z = THREE.MathUtils.clamp(mouseGroup.position.z, 2, 10);
+
+  if (!state.isJumping && keys.has(" ")) {
+    state.jumpVelocity = 0.28;
+    state.isJumping = true;
+  }
+};
+
+const updateJump = () => {
+  if (!state.isJumping) return;
+  mouseGroup.position.y += state.jumpVelocity;
+  state.jumpVelocity -= 0.012;
+  if (mouseGroup.position.y <= 0.6) {
+    mouseGroup.position.y = 0.6;
+    state.isJumping = false;
+  }
+};
+
+const checkCollisions = () => {
+  const mouseBox = new THREE.Box3().setFromObject(mouseGroup);
+  for (const obstacle of obstacles) {
+    const obstacleBox = new THREE.Box3().setFromObject(obstacle);
+    if (mouseBox.intersectsBox(obstacleBox)) {
+      state.lives -= 1;
+      obstacle.position.z = -40 - Math.random() * 30;
+      obstacle.position.x = (Math.random() - 0.5) * 8;
+      if (state.lives <= 0) {
+        state.isGameOver = true;
+        overlay?.classList.remove("hidden");
+        message.textContent = "游戏结束";
+      }
+      updateHud();
+      break;
+    }
+  }
+};
+
+const updateObstacles = () => {
+  for (const obstacle of obstacles) {
+    obstacle.position.z += state.speed;
+    if (obstacle.position.z > 12) {
+      obstacle.position.z = -40 - Math.random() * 30;
+      obstacle.position.x = (Math.random() - 0.5) * 8;
+      state.distance += 8;
+      state.speed = Math.min(0.35, state.speed + 0.002);
+      updateHud();
+    }
+  }
+};
+
+const updateCamera = () => {
+  camera.position.set(
+    mouseGroup.position.x * 0.4,
+    6.5,
+    mouseGroup.position.z + 10
+  );
+  camera.lookAt(mouseGroup.position.x, 0.6, mouseGroup.position.z - 4);
+};
+
+const animate = () => {
+  requestAnimationFrame(animate);
+  if (state.isPaused || state.isGameOver) {
+    renderer.render(scene, camera);
+    return;
+  }
+  applyControls();
+  updateJump();
+  updateObstacles();
+  checkCollisions();
+  updateCamera();
+  renderer.render(scene, camera);
+};
+
+updateHud();
+updateCamera();
+animate();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>乡下老鼠进城 3D 游戏</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div id="hud">
+      <div class="title">乡下老鼠进城</div>
+      <div class="stats">
+        <span>生命: <strong id="lives">3</strong></span>
+        <span>距离: <strong id="distance">0</strong> 米</span>
+      </div>
+      <div class="controls">
+        <span>移动: WASD / 方向键</span>
+        <span>冲刺: Shift</span>
+        <span>跳跃: Space</span>
+        <span>暂停: P</span>
+      </div>
+      <button id="restart">重新开始</button>
+    </div>
+    <div id="overlay" class="hidden">
+      <div class="panel">
+        <h1 id="message">游戏结束</h1>
+        <p>城市太危险了，老鼠需要你的帮助再试一次！</p>
+        <button id="play-again">再来一次</button>
+      </div>
+    </div>
+    <div id="loader">加载 3D 场景...</div>
+
+    <script src="https://cdn.jsdelivr.net/npm/three@0.159.0/build/three.min.js"></script>
+    <script src="game.js"></script>
+  </body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,106 @@
+:root {
+  color-scheme: dark;
+  font-family: "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  overflow: hidden;
+  background: #0d0f1a;
+}
+
+#hud {
+  position: absolute;
+  top: 20px;
+  left: 20px;
+  padding: 16px 20px;
+  background: rgba(8, 12, 28, 0.72);
+  border: 1px solid rgba(120, 141, 255, 0.4);
+  border-radius: 16px;
+  color: #e6ecff;
+  min-width: 240px;
+  z-index: 10;
+  backdrop-filter: blur(6px);
+}
+
+#hud .title {
+  font-size: 20px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+
+#hud .stats {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 8px;
+  font-size: 14px;
+}
+
+#hud .controls {
+  display: grid;
+  gap: 4px;
+  font-size: 12px;
+  color: #b4c3ff;
+  margin-bottom: 12px;
+}
+
+#hud button {
+  border: none;
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: linear-gradient(120deg, #5a70ff, #9b7bff);
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+#overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(4, 6, 12, 0.88);
+  display: grid;
+  place-items: center;
+  z-index: 20;
+}
+
+#overlay.hidden {
+  display: none;
+}
+
+#overlay .panel {
+  text-align: center;
+  padding: 28px 36px;
+  border-radius: 18px;
+  background: #121732;
+  color: #f1f4ff;
+  border: 1px solid rgba(110, 128, 255, 0.5);
+}
+
+#overlay button {
+  margin-top: 16px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: none;
+  background: #6e8cff;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+#loader {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: #b7c5ff;
+  font-size: 16px;
+  z-index: 5;
+}
+
+canvas {
+  display: block;
+}


### PR DESCRIPTION
### Motivation
- Provide an interactive 3D demo where a country mouse runs into the city and must avoid threats (cats, dogs, cars, people) with simple arcade controls and a HUD. 
- Ship a self-contained front-end prototype to demonstrate gameplay, obstacle variety, collision logic and restart flow.

### Description
- Add `index.html`, `style.css` and `game.js` implementing a Three.js scene, full-screen HUD, overlay for game over, and responsive layout. 
- Implement a simple mouse actor (composed mesh), procedurally placed city blocks, and reusable obstacle types for cats/dogs/cars/people with label sprites. 
- Add player controls (`WASD`/arrow keys, `Shift` sprint, `Space` jump, `P` pause), collision detection using bounding boxes, obstacle recycling, distance/score tracking, and speed scaling. 
- Include restart/play-again handlers, window resize handling, and lightweight visual styling for the HUD/overlay.

### Testing
- Started a static server with `python -m http.server 8000` to serve the new files, which successfully ran. 
- Ran a Playwright script that loaded `http://127.0.0.1:8000` and captured a screenshot to confirm the scene rendered (artifact: `artifacts/city-mouse-game.png`), which completed successfully. 
- No unit tests were added for this front-end prototype.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69856ffc7d5883339cb004da185eca31)